### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,8 @@
 # <!-- Use the title to describe PR changes in the imperative mood --> #
 
+<!-- Link any related issue(s) here. -->
+Related issue(s):
+
 ## 🗣 Description ##
 
 <!-- Describe the "what" of your changes in detail. -->
@@ -9,33 +12,33 @@
 
 <!-- Why is this change required? -->
 <!-- What problem does this change solve? How did you solve it? -->
-<!-- What isn't included in this PR? -->
-<!-- Mention any related issue(s) here to cross-link automatically. -->
+
+### 🛠 What isn't in this PR ###
+
+<!-- Describe what may not be covered in this PR's changes. -->
+<!-- Link new or updated issues tracking code-TODOs here. -->
 
 ## 🧪 Testing ##
 
-<!-- How did you test your changes? How could someone else test this PR? -->
+<!-- Deep-link to the relevant page the Netlify Preview, if applicable. -->
+<!-- Netlify Preview:  -->
 
-<!-- Include details of your testing environment, and the tests you ran to -->
-<!-- see how your change affects other areas of the code, etc. -->
+<!-- Add instructions for how to test the specific changes in this PR. -->
+1.
 
-## 📷 Screenshots (if appropriate) ##
+<!-- Did you test any other cases your reviewer may be interested in? -->
+<!-- Did you add or modify tests to cover the changes in this PR? -->
 
-<!-- Remove this section and header if not needed -->
+## 📷 Screenshots ##
+
+<!-- Remove this section and header if changes have no visual impact. -->
 
 ## ✅ Checklist ##
 
-<!-- Remove any of the following that do not apply. -->
-<!-- Draft PRs should have one or more unchecked boxes. -->
-<!-- If you're unsure about any of these, don't hesitate to ask! -->
+<!-- Check off any entries that aren't applicable. -->
 
 * [ ] This PR has an informative and human-readable title.
 * [ ] Changes are limited to a single goal - _eschew scope creep!_
-* [ ] _All_ future TODOs are captured in issues, which are referenced
-      in code comments and this PR.
-* [ ] All relevant type-of-change labels have been added.
-<!-- * [ ] These code changes follow [Trabian code standards](https://github.com/cisagov/development-guide). -->
-* [ ] All relevant repo and/or project documentation has been updated
-      to reflect the changes in this PR.
-* [ ] Tests have been added and/or modified to cover the changes in this PR.
+* [ ] _All_ future TODOs are captured in issues.
+* [ ] Repo README and/or project documentation has been updated.
 * [ ] All new and existing tests pass.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+# <!-- Use the title to describe PR changes in the imperative mood --> #
+
+## 🗣 Description ##
+
+<!-- Describe the "what" of your changes in detail. -->
+<!-- To avoid scope creep, limit changes to a single goal. -->
+
+## 💭 Motivation and context ##
+
+<!-- Why is this change required? -->
+<!-- What problem does this change solve? How did you solve it? -->
+<!-- What isn't included in this PR? -->
+<!-- Mention any related issue(s) here to cross-link automatically. -->
+
+## 🧪 Testing ##
+
+<!-- How did you test your changes? How could someone else test this PR? -->
+
+<!-- Include details of your testing environment, and the tests you ran to -->
+<!-- see how your change affects other areas of the code, etc. -->
+
+## 📷 Screenshots (if appropriate) ##
+
+<!-- Remove this section and header if not needed -->
+
+## ✅ Checklist ##
+
+<!-- Remove any of the following that do not apply. -->
+<!-- Draft PRs should have one or more unchecked boxes. -->
+<!-- If you're unsure about any of these, don't hesitate to ask! -->
+
+* [ ] This PR has an informative and human-readable title.
+* [ ] Changes are limited to a single goal - _eschew scope creep!_
+* [ ] _All_ future TODOs are captured in issues, which are referenced
+      in code comments and this PR.
+* [ ] All relevant type-of-change labels have been added.
+<!-- * [ ] These code changes follow [Trabian code standards](https://github.com/cisagov/development-guide). -->
+* [ ] All relevant repo and/or project documentation has been updated
+      to reflect the changes in this PR.
+* [ ] Tests have been added and/or modified to cover the changes in this PR.
+* [ ] All new and existing tests pass.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,18 +13,18 @@ Related issue(s):
 <!-- Why is this change required? -->
 <!-- What problem does this change solve? How did you solve it? -->
 
-### 🛠 What isn't in this PR ###
+## 🛠 What isn't in this PR ##
 
 <!-- Describe what may not be covered in this PR's changes. -->
 <!-- Link new or updated issues tracking code-TODOs here. -->
 
 ## 🧪 Testing ##
 
-<!-- Deep-link to the relevant page the Netlify Preview, if applicable. -->
+<!-- Uncomment and link to the relevant page the Netlify Preview, if applicable: -->
 <!-- Netlify Preview:  -->
 
-<!-- Add instructions for how to test the specific changes in this PR. -->
-1.
+<!-- Add instructions for how to test the specific changes in this PR: -->
+<!-- 1. -->
 
 <!-- Did you test any other cases your reviewer may be interested in? -->
 <!-- Did you add or modify tests to cover the changes in this PR? -->
@@ -35,7 +35,8 @@ Related issue(s):
 
 ## ✅ Checklist ##
 
-<!-- Check off any entries that aren't applicable. -->
+<!-- Check that the following are complete. -->
+<!-- For any that are not applicable, check the entry as complete. -->
 
 * [ ] This PR has an informative and human-readable title.
 * [ ] Changes are limited to a single goal - _eschew scope creep!_


### PR DESCRIPTION
Creates a pull request template that would be inherited by all repositories in the `trabian` org as a community health file. Individual repositories with their own `pull_request_template.md` file would not inherit this file.

Please take a look and provide feedback! I expect this will go through some changes before we merge it.

This PR template has been in use in several repositories with some modifications:

- https://github.com/trabian/payrailz-demo-v2/blob/main/.github/pull_request_template.md (see [examples here](https://github.com/trabian/payrailz-demo-v2/pulls))
- https://github.com/trabian/viva-first/blob/master/.github/PULL_REQUEST_TEMPLATE/standard-pr.md